### PR TITLE
MARP-1333 Missing setup path for README_DE.md

### DIFF
--- a/ldap-connector-product/zip.xml
+++ b/ldap-connector-product/zip.xml
@@ -11,8 +11,7 @@
             <directory>.</directory>
             <includes>
                 <include>product.json</include>
-                <include>README.md</include>
-                <include>README_DE.md</include>
+                <include>README*.md</include>
                 <include>**/*.png</include>
             </includes>
         </fileSet>

--- a/ldap-connector-product/zip.xml
+++ b/ldap-connector-product/zip.xml
@@ -12,6 +12,7 @@
             <includes>
                 <include>product.json</include>
                 <include>README.md</include>
+                <include>README_DE.md</include>
                 <include>**/*.png</include>
             </includes>
         </fileSet>


### PR DESCRIPTION
Included README_DE.md in pom.xml and zip.xml